### PR TITLE
Handle error on `git diff`

### DIFF
--- a/scripts/ignore-build.js
+++ b/scripts/ignore-build.js
@@ -22,5 +22,10 @@ exec('git diff HEAD^ HEAD --quiet -- ' + dependentWorkspaces.join(' '), error =>
   } else if (error.code === 1) {
     console.log('Changes in dependent workspaces, building');
     process.exit(1);
+  } else {
+    // error.code must be 2 or 128
+    // https://stackoverflow.com/questions/61742500/how-to-get-the-output-of-git-diff-command-in-shell-script
+    console.log('Error running git diff: code ' + error.code);
+    process.exit(error.code);
   }
 });


### PR DESCRIPTION
### Handle error on `git diff`
### 1. handle case when exit code is 2 or 128 on `git diff`
https://stackoverflow.com/questions/61742500/how-to-get-the-output-of-git-diff-command-in-shell-script
